### PR TITLE
Update doc to install dylint-link tool.

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -16,7 +16,7 @@ The first tool we will be installing is [`cargo-contract`](https://github.com/pa
 
 As a pre-requisite for the tool you need to install the [binaryen](https://github.com/WebAssembly/binaryen) package, which is used to optimize the WebAssembly bytecode of the contract.
 
-[Dylint](https://github.com/trailofbits/dylint) tool is also required to be installed to help on the rust linting.
+[dylint-link](https://github.com/trailofbits/dylint) tool is also required to be installed to help on the rust linting.
 
 ```bash
 cargo install dylint-link

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -16,10 +16,10 @@ The first tool we will be installing is [`cargo-contract`](https://github.com/pa
 
 As a pre-requisite for the tool you need to install the [binaryen](https://github.com/WebAssembly/binaryen) package, which is used to optimize the WebAssembly bytecode of the contract.
 
-[dylint-link](https://github.com/trailofbits/dylint) tool is also required to be installed to help on the rust linting.
+Two other dependencies are needed to lint the ink! contract. This is done to warn users about using e.g. API's in a way that could lead to security issues.
 
 ```bash
-cargo install dylint-link
+cargo install cargo-dylint dylint-link
 ```
 
 Many package managers have it available nowadays ‒ e.g. there is a package for [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen),

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -16,6 +16,12 @@ The first tool we will be installing is [`cargo-contract`](https://github.com/pa
 
 As a pre-requisite for the tool you need to install the [binaryen](https://github.com/WebAssembly/binaryen) package, which is used to optimize the WebAssembly bytecode of the contract.
 
+[Dylint](https://github.com/trailofbits/dylint) tool is also required to be installed to help on the rust linting.
+
+```bash
+cargo install dylint-link
+```
+
 Many package managers have it available nowadays ‒ e.g. there is a package for [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen),
 [Homebrew](https://formulae.brew.sh/formula/binaryen) and [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/).
 


### PR DESCRIPTION
This PR is for issue #59 
Update the doc to have the developer install the dylint-link tool before installing the cargo-contract.
