### PR TITLE
Migrate to ink.substrate.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `ink-docs`
 
-This is the documentation portal for [ink!](https://github.com/paritytech/ink). The latest version is always available at [https://paritytech.github.io/ink-docs](https://paritytech.github.io/ink-docs).
+This is the documentation portal for [ink!](https://github.com/paritytech/ink). The latest version is always available at [https://ink.substrate.io](https://ink.substrate.io).
 
 Run it locally via
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,10 +1,8 @@
-const BASE_URL = process.env.NODE_ENV === 'development' ? '/' : '/ink-docs/';
-
 module.exports = {
   title: 'ink! documentation',
   tagline: 'documentation for ink!',
   url: 'https://github.com/paritytech/ink',
-  baseUrl: BASE_URL,
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',
   organizationName: 'paritytech',


### PR DESCRIPTION
Migrating to custom domain requires the base URL to be `/` 

![ink-gh-error](https://user-images.githubusercontent.com/7956429/168255751-c30cdb90-1b57-4694-8dba-52cdc9aed359.png)

