### PR TITLE
Add note about `Mapping` being lazy

### DIFF
--- a/docs/datastructures/overview.md
+++ b/docs/datastructures/overview.md
@@ -40,5 +40,9 @@ item will still be loaded from storage. As a reminder, this means accessing the
 underlying database and SCALE decoding the value. This can incur high costs, especially
 as the number of elements in `b` grows.
 
-> **Note:** Eager loading does **not** apply to `Mapping` fields, though, as key lookups in mappings
+:::note
+
+Eager loading does **not** apply to `Mapping` fields, though, as key lookups in mappings
 are done directly from contract storage.
+
+:::

--- a/docs/datastructures/overview.md
+++ b/docs/datastructures/overview.md
@@ -14,11 +14,8 @@ to implement any high level functionality themselves.
 
 ## Eager Loading
 
-When executing a contract, all* the fields of the `#[ink(storage)]` struct will be pulled
+When executing a contract, all the fields of the `#[ink(storage)]` struct will be pulled
 from storage, regardless of whether or not they are used during the message execution.
-
-Note*: This does **not** apply to `Mapping` fields, though, as key lookups in mappings
-are done directly from contract storage.
 
 Smart contract authors should be aware of this behaviour since it could potentially
 affect their contract performance. For example, consider the following storage struct:
@@ -42,3 +39,6 @@ In `EagerLoading::read_a()` we only read the `a` storage item. However, the `b` 
 item will still be loaded from storage. As a reminder, this means accessing the
 underlying database and SCALE decoding the value. This can incur high costs, especially
 as the number of elements in `b` grows.
+
+> **Note:** Eager loading does **not** apply to `Mapping` fields, though, as key lookups in mappings
+are done directly from contract storage.

--- a/docs/datastructures/overview.md
+++ b/docs/datastructures/overview.md
@@ -14,8 +14,11 @@ to implement any high level functionality themselves.
 
 ## Eager Loading
 
-When executing a contract, all the fields of the `#[ink(storage)]` struct will be pulled
+When executing a contract, all* the fields of the `#[ink(storage)]` struct will be pulled
 from storage, regardless of whether or not they are used during the message execution.
+
+Note*: This does **not** apply to `Mapping` fields, though, as key lookups in mappings
+are done directly from contract storage.
 
 Smart contract authors should be aware of this behaviour since it could potentially
 affect their contract performance. For example, consider the following storage struct:


### PR DESCRIPTION
AFAICT from reading code, the `Mapping` type is lazy in the sense that
it loads keys directly from storage. From my experience reading the
documentation and the `Eager Loading` paragraph, it is confusing,
because it implies `Mapping` is also eagerly loaded.

This PR proposes a small change to the wording such that it is explicit
how `Mapping` works.

If I've misunderstood how `Mapping` works, sorry for the noise, please
ignore this PR and please share the relevant parts of code that I can
look at.

Thanks!