### PR TITLE
Change Contracts UI url

### DIFF
--- a/docs/intro/ink-vs-cosmwasm.md
+++ b/docs/intro/ink-vs-cosmwasm.md
@@ -140,7 +140,7 @@ CosmWasm contracts are deployed and instantiated with help of the `wasmd` execut
 list of step is provided [here](https://docs.cosmwasm.com/docs/1.0/getting-started/interact-with-contract).
 
 It is possible to deploy and interact with ink! contracts using either a CLI
-(`cargo-contract`), or a web UI ([`contracts-ui`](https://paritytech.github.io/contracts-ui/)).
+(`cargo-contract`), or a web UI ([`contracts-ui`](https://contracts-ui.substrate.io/)).
 
 - [Instructions for `cargo-contract`](https://github.com/paritytech/cargo-contract/blob/master/docs/extrinsics.md)
 - [Instructions for `contracts-ui`](/getting-started/deploy-your-contract)

--- a/docs/testnet/overview.md
+++ b/docs/testnet/overview.md
@@ -69,5 +69,5 @@ The following graphic depicts the idea:
 There are also different user interfaces and command-line tools you can use to deploy
 or interact with contracts:
 
-* [Contracts UI](https://paritytech.github.io/contracts-ui/)
+* [Contracts UI](https://contracts-ui.substrate.io/)
 * [polkadot-js](https://polkadot.js.org/apps/)


### PR DESCRIPTION
The app is now available at https://contracts-ui.substrate.io/