### PR TITLE
Re-order dependency installation steps

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -16,12 +16,6 @@ The first tool we will be installing is [`cargo-contract`](https://github.com/pa
 
 As a pre-requisite for the tool you need to install the [binaryen](https://github.com/WebAssembly/binaryen) package, which is used to optimize the WebAssembly bytecode of the contract.
 
-Two other dependencies are needed to lint the ink! contract. This is done to warn users about using e.g. API's in a way that could lead to security issues.
-
-```bash
-cargo install cargo-dylint dylint-link
-```
-
 Many package managers have it available nowadays ‒ e.g. there is a package for [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen),
 [Homebrew](https://formulae.brew.sh/formula/binaryen) and [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/).
 
@@ -36,6 +30,12 @@ cargo install cargo-contract --force --locked
 Use the `--force` to ensure you are updated to the most recent `cargo-contract` version.
 
 You can then use `cargo contract --help` to start exploring the commands made available to you.
+
+Two other dependencies are needed to lint the ink! contract. This is done to warn users about using e.g. API's in a way that could lead to security issues.
+
+```bash
+cargo install cargo-dylint dylint-link
+```
 
 ## Substrate Framework Pre-requisites
 


### PR DESCRIPTION
dylint-link tool install docs was dropped in the middle of binaryen install instructions in this commit https://github.com/paritytech/ink-docs/commit/9441b53e8bd0baae19b39ecf90f7f9dddeb25594. As it is now stands does not read correctly and somewhat confusing. This commit connects binaryyen install instructions together as a whole again, and drops new docs at the bottom of the section.