### PR TITLE
Added usage of Enum in basics-storing values page 

### DIFF
--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -72,13 +72,13 @@ Enum can be used as a datatype in `struct` as depicted above in `struct Auction`
 
 ```rust
 pub enum Status {
-        /// An auction has not started yet.
-        NotStarted,
-        /// We are in the starting period of the auction, collecting initial bids.
-        OpeningPeriod,
-        /// We are in the ending period of the auction, where we are taking snapshots of the winning
-        /// bids. 
-    }
+    /// An auction has not started yet.
+    NotStarted,
+    /// We are in the starting period of the auction, collecting initial bids.
+    OpeningPeriod,
+    /// We are in the ending period of the auction, where we are taking snapshots
+    /// of the winning bids. 
+}
 ```
 The values of enum should be referenced as `Status::OpeningPeriod`
 ## Initializing Storage in Constructors

--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -53,16 +53,16 @@ Here is an example of a structure storing `String` and  `Hash` values.
 ```rust
 pub struct Auction {
     /// Branded name of the auction event.
-        name: String,
-        /// Some hash identifying the auction subject.
-        subject: Hash,
-         /// Auction status.
-         status: Status, //Enum: Usage shown in next section
-        /// Candle auction can have no winner.
-        /// If auction is finalized, that means that the winner is determined.
-        finalized: bool,
-        /// vector
-        vector: Vec<u8>,
+    name: String,
+    /// Some hash identifying the auction subject.
+    subject: Hash,
+    /// Auction status.
+    status: Status, // Enum: Usage shown in next section
+    /// Candle auction can have no winner.
+    /// If auction is finalized, that means that the winner is determined.
+    finalized: bool,
+    /// vector
+    vector: Vec<u8>,
 }
 ```
 

--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -77,13 +77,10 @@ pub enum Status {
         /// We are in the starting period of the auction, collecting initial bids.
         OpeningPeriod,
         /// We are in the ending period of the auction, where we are taking snapshots of the winning
-        /// bids. Snapshots are taken currently on per-block basis, but this logic could be later evolve
-        /// to take snapshots of on arbitrary length (in blocks).
-        EndingPeriod(BlockNumber),
-        /// Candle was blown.
+        /// bids. 
     }
 ```
-
+The values of enum should be referenced as `Status::OpeningPeriod`
 ## Initializing Storage in Constructors
 
 Constructors are how values get initialized.

--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -48,6 +48,41 @@ mod MyContract {
     /* --snip-- */
 }
 ```
+Here is an example of a structure storing `String` and  `Hash` values. 
+
+```rust
+pub struct Auction {
+    /// Branded name of the auction event.
+        name: String,
+        /// Some hash identifying the auction subject.
+        subject: Hash,
+         /// Auction status.
+         status: Status, //Enum: Usage shown in next section
+        /// Candle auction can have no winner.
+        /// If auction is finalized, that means that the winner is determined.
+        finalized: bool,
+        /// vector
+        vector: Vec<u8>,
+}
+```
+
+## Use of enum 
+
+Enum can be used as a datatype in `struct` as depicted above in `struct Auction`
+
+```rust
+pub enum Status {
+        /// An auction has not started yet.
+        NotStarted,
+        /// We are in the starting period of the auction, collecting initial bids.
+        OpeningPeriod,
+        /// We are in the ending period of the auction, where we are taking snapshots of the winning
+        /// bids. Snapshots are taken currently on per-block basis, but this logic could be later evolve
+        /// to take snapshots of on arbitrary length (in blocks).
+        EndingPeriod(BlockNumber),
+        /// Candle was blown.
+    }
+```
 
 ## Initializing Storage in Constructors
 


### PR DESCRIPTION
I felt the basics page needed some explanation about Enum and the usage of strings and hash. So I've added it, thank you!