### PR TITLE
Update link to docs

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -4,7 +4,7 @@ slug: /getting-started/setup
 ---
 
 In case you are looking for a guided tutorial directed
-towards beginners please check out our [Guided Tutorial](https://docs.substrate.io/tutorials/v3/ink-workshop/pt1).
+towards beginners please check out our [Smart contract tutorial page](https://docs.substrate.io/tutorials/smart-contracts/).
 
 ## Rust & Cargo
 


### PR DESCRIPTION
Updating to point users to the different Smart contract tutorials we have in our docs (replacing old link).