### PR TITLE
Add contract manifest changes to migration guide

### DIFF
--- a/docs/faq/migrating-from-ink-3-to-4.md
+++ b/docs/faq/migrating-from-ink-3-to-4.md
@@ -316,7 +316,6 @@ You should also now consider dealing with `AccountId`'s as `Option<AccountId>`'s
 more idomatic Rust, and also conveys the meaning of a "null" or "empty" address much
 better.
 
-
 ## Updates to the `CallBuilder` and `CreateBuilder` APIs
 There's been several changes to the
 [`CallBuilder`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html) 
@@ -354,3 +353,31 @@ workflows:
 - For `Call` you can use
   [`CallBuilder::call()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.call) (this replaces `CallBuilder::callee()`)
 - For `DelegateCall` you can use [`CallBuilder::delegate()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.delegate)
+
+## Removal of `[lib.crate-type]` and `[lib.name]` from contract manifest
+Earlier versions of `cargo-contract` required that these two fields were specified in the
+contract manifest explicitly, as follows:
+
+```toml
+[lib]
+name = "flipper"
+path = "lib.rs"
+crate-type = [
+    # Used for normal contract Wasm blobs.
+    "cdylib",
+    # Use to generate ABI
+    "rlib",
+]
+```
+
+However, with with [cargo-contract#929](https://github.com/paritytech/cargo-contract/pull/929) we changed this behaviour to:
+- Use the contract name by default, removing the need for the `name` field
+- Compile contracts as `rlib`s by default, and automatically changing to `cdylib` as
+  needed
+
+This means that your new manifest should look like:
+
+```toml
+[lib]
+path = "lib.rs"
+```


### PR DESCRIPTION
This change is a bit subtle since old contracts would still compile correctly with the
the `crate-type` still set explicitly. However, for usability reasons contract authors
should remov this and let `cargo-contract` set it on their behalf.

I've also noticed that some of the example ink! contracts still have these fields in
their manifest, so we should open a few follow-ups to update that.
