### PR TITLE
Remove `--tmp` flag from 3.x tutorials

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs/current/getting-started/troubleshooting.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/getting-started/troubleshooting.md
@@ -16,7 +16,7 @@ poniendo tu ordenador a dormis, etc...), obtendras el siguiente error:
 ```bash
 ClientImport("Unexpected epoch change")
 ```
-Para solucionar esto necesitaras rearrancar el nodo con: `substrate-contracts-node --dev --tmp`. En este punto, necesitaras redesplegar 
+Para solucionar esto necesitaras rearrancar el nodo con: `substrate-contracts-node --dev`. En este punto, necesitaras redesplegar 
 cualquier contrato y rehacer todos los pasos que has hecho previamente en tu nodo. Mientras mantengas el nodo corriendo, no deberías encontrarte errores.
 
 ### Viejos Contratos en Local Storage

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/faq/faq.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/faq/faq.md
@@ -137,7 +137,7 @@ you compile a contract in `--release` mode.
 1. __Set the log level of your node to `runtime::contracts=debug`.__<br/>
   For example, to have only errors and debug output show up for the `substrate-contracts-node`: 
   ```
-  substrate-contracts-node --dev --tmp -lerror,runtime::contracts=debug
+  substrate-contracts-node --dev -lerror,runtime::contracts=debug
   ```
 
 __Important: Debug output is only printed for RPC calls or off-chain tests ‒ not for transactions!__

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/getting-started/running.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/getting-started/running.md
@@ -11,7 +11,7 @@ It's a comfortable option if you want to get a quickstart.
 [After successfully installing `substrate-contracts-node`](/getting-started/setup), you can start a local development chain by running:
 
 ```bash
-substrate-contracts-node --dev --tmp
+substrate-contracts-node --dev
 ```
 
 ![An image of the terminal starting a Substrate node](./assets/start-substrate-node.png)

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/getting-started/troubleshooting.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/getting-started/troubleshooting.md
@@ -13,7 +13,7 @@ There is a known issue with the Substrate block production (BABE) on a running c
 ClientImport("Unexpected epoch change")
 ```
 
-To solve this you will need to restart your node with: `substrate-contracts-node --dev --tmp`. At that point, you will
+To solve this you will need to restart your node with: `substrate-contracts-node --dev`. At that point, you will
 need to re-deploy any contracts and re-do any steps that you may have done before on your node. As
 long as you keep your node running, you should face no issues.
 


### PR DESCRIPTION
The lastest releases in the 3.x series use `substrate-contracts-node`
`v0.13.0` which doesn't require the `--tmp` flag, but still requires the
`--dev` flag.

Related issue: https://github.com/paritytech/ink/issues/1007