### PR TITLE
Updated faucet plugin to use the new endpoint

### DIFF
--- a/docs/testnet/Faucet.tsx
+++ b/docs/testnet/Faucet.tsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 
 const RECAPTCHA_SITE_KEY = "6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe"
-const FAUCET_URL = "https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip"
+const FAUCET_URL = "https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip/web"
 
 export const Faucet = () => {
   const [captcha, setCaptcha] = useState<string | null>(null)

--- a/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 
 const RECAPTCHA_SITE_KEY = "6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe"
-const FAUCET_URL = "https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip"
+const FAUCET_URL = "https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip/web"
 
 export const Faucet = () => {
   const [captcha, setCaptcha] = useState<string | null>(null)

--- a/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
@@ -47,11 +47,11 @@ export const Faucet = () => {
     <div className="faucetContainer">
       <h3 className="faucetTitle">Obten Tokens para la Testnet</h3>
       <div className="faucetPlantContainer">
-        <img src="/img/plantOne.svg" alt="illustration of a sea grass plant" className="faucetPlantOne" />
-        <img src="/img/plantTwo.svg" alt="illustration of a sea plant" className="faucetPlantTwo" />
+        <img src="/img/plantOne.svg" alt="illustración de una alga marina" className="faucetPlantOne" />
+        <img src="/img/plantTwo.svg" alt="illustración de una planta marina" className="faucetPlantTwo" />
       </div>
       <div className="faucetHeroContainer">
-        <img src="/img/chest.svg" alt="image of a treasure chest" className="faucetHeroImage" />
+        <img src="/img/chest.svg" alt="imagen de un cofre del tesoro" className="faucetHeroImage" />
       </div>
       <form className="withHero">
         <fieldset>


### PR DESCRIPTION
Updated the faucet plugin to use the new endpoint: `/drip/web`

This commit will close https://github.com/paritytech/substrate-matrix-faucet/issues/215

The reason for which we updated the endpoint is that the previous endpoints switches between the bot and the docs, and with the new change the endpoint will exclusively work with the web removing all of the code bot. You can find the commit here: https://github.com/paritytech/substrate-matrix-faucet/commit/56130249044c67d12fa9a434c13314d032d55d22

@rzadp has helped me test it. [This is his advice on how to do so](https://github.com/paritytech/ink-docs/pull/145#issuecomment-1423869427)
