### PR TITLE
Ignore old version for search plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,7 @@ module.exports = {
         ignoreFiles: [
           /3.x/,
         ],
+        language: ["en", "es"]
       }
     ]
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,6 +25,9 @@ module.exports = {
       require.resolve("@easyops-cn/docusaurus-search-local"),
       {
         indexPages: true,
+        ignoreFiles: [
+          /3.x/,
+        ],
       }
     ]
   ],


### PR DESCRIPTION
Closes https://github.com/paritytech/ink-docs/issues/181.

Configuration details here: https://github.com/easyops-cn/docusaurus-search-local.

The solution of just ignoring old versions for the search is not ideal, but it's the most trivial solution that I could find for this plugin.