### PR TITLE
Setting CONTRACTS_NODE env for nodes other than substrate-contracts-node

### DIFF
--- a/docs/basics/testing.md
+++ b/docs/basics/testing.md
@@ -165,18 +165,21 @@ async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
 You can run the above test by going to the `flipper` folder in
 [the ink! examples directory](https://github.com/paritytech/ink-examples/tree/main).
 
-Before you can run the test, you have to start a Substrate
-node with `pallet-contracts` in the background.
-You can use e.g. our [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node)
-for this. Start the node in one shell session/terminal window via
+Before you can run the test, you have to install a Substrate
+node with `pallet-contracts`. By default e2e tests require that you install [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node). You do not need to run it in the background since the tests will automatically start the node for each test independently.
+To install the latest version:
 
+```sh
+cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git
 ```
-substrate-contracts-node
+If you want to run any other node with `pallet-contracts` you need to change `CONTRACTS_NODE` environment variable:
+
+```sh
+export CONTRACTS_NODE="YOUR_CONTRACTS_NODE_PATH"
 ```
 
-Then, while keeping the node running, execute the following command
-in another shell session/terminal window.
+And finally execute the following command to start e2e test execution.
 
-```
+```sh
 cargo test --features e2e-tests
 ```

--- a/docs/basics/testing.md
+++ b/docs/basics/testing.md
@@ -166,7 +166,7 @@ You can run the above test by going to the `flipper` folder in
 [the ink! examples directory](https://github.com/paritytech/ink-examples/tree/main).
 
 Before you can run the test, you have to install a Substrate
-node with `pallet-contracts`. By default e2e tests require that you install [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node). You do not need to run it in the background since the tests will automatically start the node for each test independently.
+node with `pallet-contracts`. By default e2e tests require that you install [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node). You do not need to run it in the background since the node is started for each test independently.
 To install the latest version:
 
 ```sh


### PR DESCRIPTION
- The e2e testing doc is not stating that in order to run any other node with `pallet-contracts` you need to change CONTRACTS_NODE environment variable.
- It is also stated that you need to run the node in the background while this is not the case.
- The PR is partially based on [SE](https://substrate.stackexchange.com/questions/7632/error-running-e2e-tests-on-flipper) answer by @cmichi.