### PR TITLE
Fix alternate language metadata links

### DIFF
--- a/docs/intro/how-it-works.md
+++ b/docs/intro/how-it-works.md
@@ -2,6 +2,7 @@
 title: How it Works – Substrate
 hide_title: true
 slug: /how-it-works
+slug.es: /como-funciona
 ---
 
 <img src="/img/title/substrate.svg" className="titlePic" />

--- a/docs/intro/why-rust.md
+++ b/docs/intro/why-rust.md
@@ -4,6 +4,14 @@ hide_title: true
 slug: /why-rust-for-smart-contracts
 ---
 
+<head>
+<link
+          rel="alternate"
+          href="/es/por-que-rust-para-smart-contracts"
+          hrefLang="es-ES"
+        />
+</head>
+
 <img src="/img/title/rust.svg" className="titlePic" />
 
 # Why Rust for Smart Contracts?
@@ -27,7 +35,7 @@ Also, Rust has an integrated test and benchmark runner,
 
 * <span class="highlight">1st class Wasm:</span> Rust provides the first class support for the WebAssembly.
 
-* <span class="highlight">Small Size:</span> In the space-constrained blockchain world size is important. 
-The Rust compiler is a great help for that, since it reorders struct fields in order 
+* <span class="highlight">Small Size:</span> In the space-constrained blockchain world size is important.
+The Rust compiler is a great help for that, since it reorders struct fields in order
 to make each type as small as possible. Thus, Rust data structures are very compact,
 in many cases even more compact than in C.

--- a/docs/intro/why-rust.md
+++ b/docs/intro/why-rust.md
@@ -2,15 +2,9 @@
 title: Why Rust for Smart Contracts?
 hide_title: true
 slug: /why-rust-for-smart-contracts
+slug.es: /por-que-rust-para-smart-contracts
 ---
 
-<head>
-<link
-          rel="alternate"
-          href="/es/por-que-rust-para-smart-contracts"
-          hrefLang="es-ES"
-        />
-</head>
 
 <img src="/img/title/rust.svg" className="titlePic" />
 

--- a/docs/intro/why-rust.md
+++ b/docs/intro/why-rust.md
@@ -5,7 +5,6 @@ slug: /why-rust-for-smart-contracts
 slug.es: /por-que-rust-para-smart-contracts
 ---
 
-
 <img src="/img/title/rust.svg" className="titlePic" />
 
 # Why Rust for Smart Contracts?

--- a/docs/intro/why-webassembly.md
+++ b/docs/intro/why-webassembly.md
@@ -2,6 +2,7 @@
 title: Why WebAssembly for Smart Contracts?
 hide_title: true
 slug: /why-webassembly-for-smart-contracts
+slug.es: /por-que-webassembly-para-smart-contracts
 ---
 
 <img src="/img/title/wasm.svg" className="titlePic" />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,6 +40,7 @@ module.exports = {
         language: ['en', 'es'],
       },
     ],
+    'docusaurus-theme-frontmatter',
   ],
   themeConfig: {
     prism: {

--- a/i18n/es/docusaurus-plugin-content-docs/current/intro/how-it-works.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/intro/how-it-works.md
@@ -1,7 +1,8 @@
 ---
 title: Cómo funciona ‒ Substrate
-slug: /como-funciona
 hide_title: true
+slug: /como-funciona
+slug.en: /how-it-works
 ---
 
 <img src="/img/title/substrate.svg" className="titlePic" />

--- a/i18n/es/docusaurus-plugin-content-docs/current/intro/why-rust.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/intro/why-rust.md
@@ -4,6 +4,14 @@ slug: /por-que-rust-para-smart-contracts
 hide_title: true
 ---
 
+<head>
+<link
+          rel="alternate"
+          href="/why-rust-for-smart-contracts"
+          hrefLang="en-US"
+        />
+</head>
+
 <img src="/img/title/rust.svg" className="titlePic" />
 
 # Por qué Rust para Smart Contracts?

--- a/i18n/es/docusaurus-plugin-content-docs/current/intro/why-rust.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/intro/why-rust.md
@@ -1,16 +1,9 @@
 ---
 title: Por qué Rust para Smart Contracts?
 slug: /por-que-rust-para-smart-contracts
+slug.en: /why-rust-for-smart-contracts
 hide_title: true
 ---
-
-<head>
-<link
-          rel="alternate"
-          href="/why-rust-for-smart-contracts"
-          hrefLang="en-US"
-        />
-</head>
 
 <img src="/img/title/rust.svg" className="titlePic" />
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/intro/why-webassembly.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/intro/why-webassembly.md
@@ -1,7 +1,8 @@
 ---
 title: Por qué WebAssembly para Smart Contracts?
-slug: /por-que-webassembly-para-smart-contracts
 hide_title: true
+slug: /por-que-webassembly-para-smart-contracts
+slug.en: /why-webassembly-for-smart-contracts
 ---
 
 <img src="/img/title/wasm.svg" className="titlePic" />
@@ -13,10 +14,10 @@ Estas fueron las razones por las que tomamos dicha decisión:
 
 * <span class="highlight">Alta performance: </span>Wasm es de alta performance — está desarrollados para estar lo más próximo posible al código nativo de la computadora, aún manteniendo una plataforma independiente.
 
-* <span class="highlight">Tamaño compacto: </span>Facilita un binario compacto que puede enviarse a través de internet a dispositivos con, potencialmente, conexiones lentas. 
+* <span class="highlight">Tamaño compacto: </span>Facilita un binario compacto que puede enviarse a través de internet a dispositivos con, potencialmente, conexiones lentas.
 Esto lo hace ideal para sistemas con restricciones de espacio, como los Blockchains.
 
-* <span class="highlight">Máquina Virtual (VM) General & bytecode: </span> 
+* <span class="highlight">Máquina Virtual (VM) General & bytecode: </span>
 Fue desarrollado para que el código pueda ser deployado en cualquier browser con el mismo resultado.
 Contrario a EVM que no fue desarrollado para un caso particular, Wasm tiene el befecio de contar con una gran cantidad de herramientas disponibles y de una gran canditat de compañías que dedican recursos en el desarrollo futuro de Wasm.
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@lottiefiles/lottie-player": "^1.7.1",
     "autoprefixer": "^10.4.14",
     "classnames": "^2.3.2",
+    "docusaurus-theme-frontmatter": "^1.3.0",
     "lottie-react": "^2.4.0",
     "postcss": "^8.4.21",
     "react-google-recaptcha": "^2.1.0",

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -1,9 +1,7 @@
 import Head from '@docusaurus/Head'
 import { useAlternatePageUtils, useDoc } from '@docusaurus/theme-common/internal'
-
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import MDXContent from '@theme-original/MDXContent'
-import useFrontMatter from '@theme/useFrontMatter'
 import React from 'react'
 
 // Adapted version from ejected SiteMetadata.js to allow for custom local slugs

--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -1,0 +1,67 @@
+import Head from '@docusaurus/Head'
+import { useAlternatePageUtils, useDoc } from '@docusaurus/theme-common/internal'
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import MDXContent from '@theme-original/MDXContent'
+import useFrontMatter from '@theme/useFrontMatter'
+import React from 'react'
+
+// Adapted version from ejected SiteMetadata.js to allow for custom local slugs
+// https://github.com/paritytech/ink-docs/issues/211
+function AlternateLangHeaders() {
+  const alternatePageUtils = useAlternatePageUtils()
+  const {
+    i18n: { defaultLocale, localeConfigs },
+  } = useDocusaurusContext()
+  const { frontMatter } = useDoc()
+
+  const availableSlugs = React.useMemo(
+    () =>
+      Object.entries(frontMatter)
+        .filter(([key]) => key.startsWith('slug'))
+        .map(([key, value]) => {
+          const locale = key.split('.')[1]
+          if (locale) return [locale, value]
+          return [defaultLocale, value]
+        })
+        .reduce((acc, [locale, value]) => {
+          acc[locale] = value
+          return acc
+        }, {}),
+    [frontMatter],
+  )
+
+  return (
+    <Head>
+      {Object.entries(localeConfigs).map(([locale, { htmlLang }]) => {
+        let href = alternatePageUtils.createUrl({
+          locale,
+          fullyQualified: true,
+        })
+
+        const customSlug = availableSlugs[locale] || availableSlugs[htmlLang]
+
+        if (customSlug) href = href.replace(new RegExp(`(.*${locale})(.*)`), `$1${customSlug}`)
+
+        return <link key={locale} rel="alternate" href={href} hrefLang={htmlLang} />
+      })}
+      <link
+        rel="alternate"
+        href={alternatePageUtils.createUrl({
+          locale: defaultLocale,
+          fullyQualified: true,
+        })}
+        hrefLang="x-default"
+      />
+    </Head>
+  )
+}
+
+export default function MDXContentWrapper(props) {
+  return (
+    <>
+      <AlternateLangHeaders />
+      <MDXContent {...props} />
+    </>
+  )
+}

--- a/src/theme/SiteMetadata/index.js
+++ b/src/theme/SiteMetadata/index.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import Head from '@docusaurus/Head'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+import { PageMetadata, useThemeConfig } from '@docusaurus/theme-common'
+import { DEFAULT_SEARCH_TAG, useAlternatePageUtils, keyboardFocusedClassName } from '@docusaurus/theme-common/internal'
+import { useLocation } from '@docusaurus/router'
+import SearchMetadata from '@theme/SearchMetadata'
+// TODO move to SiteMetadataDefaults or theme-common ?
+// Useful for i18n/SEO
+// See https://developers.google.com/search/docs/advanced/crawling/localized-versions
+// See https://github.com/facebook/docusaurus/issues/3317
+function AlternateLangHeaders() {
+  const {
+    i18n: { defaultLocale, localeConfigs },
+  } = useDocusaurusContext()
+  const alternatePageUtils = useAlternatePageUtils()
+  // Note: it is fine to use both "x-default" and "en" to target the same url
+  // See https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
+  return (
+    <Head>
+      {/* {Object.entries(localeConfigs).map(([locale, { htmlLang }]) => (
+        <link
+          key={locale}
+          rel="alternate"
+          href={alternatePageUtils.createUrl({
+            locale,
+            fullyQualified: true,
+          })}
+          hrefLang={htmlLang}
+        />
+      ))} */}
+      <link
+        rel="alternate"
+        href={alternatePageUtils.createUrl({
+          locale: defaultLocale,
+          fullyQualified: true,
+        })}
+        hrefLang="x-default"
+      />
+    </Head>
+  )
+}
+// Default canonical url inferred from current page location pathname
+function useDefaultCanonicalUrl() {
+  const {
+    siteConfig: { url: siteUrl },
+  } = useDocusaurusContext()
+  const { pathname } = useLocation()
+  return siteUrl + useBaseUrl(pathname)
+}
+// TODO move to SiteMetadataDefaults or theme-common ?
+function CanonicalUrlHeaders({ permalink }) {
+  const {
+    siteConfig: { url: siteUrl },
+  } = useDocusaurusContext()
+  const defaultCanonicalUrl = useDefaultCanonicalUrl()
+  const canonicalUrl = permalink ? `${siteUrl}${permalink}` : defaultCanonicalUrl
+  return (
+    <Head>
+      <meta property="og:url" content={canonicalUrl} />
+      <link rel="canonical" href={canonicalUrl} />
+    </Head>
+  )
+}
+export default function SiteMetadata() {
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext()
+  // TODO maybe move these 2 themeConfig to siteConfig?
+  // These seems useful for other themes as well
+  const { metadata, image: defaultImage } = useThemeConfig()
+  return (
+    <>
+      <Head>
+        <meta name="twitter:card" content="summary_large_image" />
+        {/* The keyboard focus class name need to be applied when SSR so links
+        are outlined when JS is disabled */}
+        <body className={keyboardFocusedClassName} />
+      </Head>
+
+      {defaultImage && <PageMetadata image={defaultImage} />}
+
+      <CanonicalUrlHeaders />
+
+      <AlternateLangHeaders />
+
+      <SearchMetadata tag={DEFAULT_SEARCH_TAG} locale={currentLocale} />
+
+      {/*
+          It's important to have an additional <Head> element here, as it allows
+          react-helmet to override default metadata values set in previous <Head>
+          like "twitter:card". In same Head, the same meta would appear twice
+          instead of overriding.
+        */}
+      <Head>
+        {/* Yes, "metadatum" is the grammatically correct term */}
+        {metadata.map((metadatum, i) => (
+          <meta key={i} {...metadatum} />
+        ))}
+      </Head>
+    </>
+  )
+}

--- a/src/theme/SiteMetadata/index.js
+++ b/src/theme/SiteMetadata/index.js
@@ -19,7 +19,7 @@ function AlternateLangHeaders() {
   // See https://www.searchviu.com/en/multiple-hreflang-tags-one-url/
   return (
     <Head>
-      {/* {Object.entries(localeConfigs).map(([locale, { htmlLang }]) => (
+      {Object.entries(localeConfigs).map(([locale, { htmlLang }]) => (
         <link
           key={locale}
           rel="alternate"
@@ -29,7 +29,7 @@ function AlternateLangHeaders() {
           })}
           hrefLang={htmlLang}
         />
-      ))} */}
+      ))}
       <link
         rel="alternate"
         href={alternatePageUtils.createUrl({
@@ -83,7 +83,9 @@ export default function SiteMetadata() {
 
       <CanonicalUrlHeaders />
 
-      <AlternateLangHeaders />
+      {/* Not use here anymore, moved to Wrapped MDXContent as we need the document Frontmatter */}
+      {/* https://github.com/paritytech/ink-docs/issues/211 */}
+      {/* <AlternateLangHeaders /> */}
 
       <SearchMetadata tag={DEFAULT_SEARCH_TAG} locale={currentLocale} />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4611,6 +4611,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docusaurus-theme-frontmatter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-theme-frontmatter/-/docusaurus-theme-frontmatter-1.3.0.tgz#6691a80e8b510af65ddfcface50f3699309b8770"
+  integrity sha512-T/p4immO1mRdP9ok+7f8fRK+Eee2Hqv7sndgmt1mtnWKAHWbHg5N5SAG2oON27/nzv5y3Mo6GpbRkXbQC86zdw==
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
Discussed in #211. IMHO it's not worth this hassle for minor seo improvements. 🤷 

Maybe a plugin solution is more maintainable but not an docusaurus plugin expert.



### Explanation:

1. Swizzle ejected `SiteMetadata` (considered unsafe)
2. disabled `<AlternateLangHeader/>` in `SiteMetadata`

https://github.com/paritytech/ink-docs/blob/e69f0da6a3e3eec264b45c98d673fa8f885902b4/src/theme/SiteMetadata/index.js#L86-L88

3. created very similiar but adapted `<AlternateLangHeader/>` in swizzle wrapped `MDXContent`

https://github.com/paritytech/ink-docs/blob/e69f0da6a3e3eec264b45c98d673fa8f885902b4/src/theme/MDXContent/index.js#L68


### Demo

https://user-images.githubusercontent.com/839848/229807678-6b211b14-5288-408f-a026-8ed21f5a9861.mov
