### PR TITLE
feat: add autofill for faucet via query param

### DIFF
--- a/docs/testnet/Faucet.tsx
+++ b/docs/testnet/Faucet.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import ReCAPTCHA from 'react-google-recaptcha'
 
 const RECAPTCHA_SITE_KEY = '6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe'
@@ -6,7 +6,11 @@ const FAUCET_URL = 'https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip
 
 const Faucet = () => {
   const [captcha, setCaptcha] = useState<string | null>(null)
-  const [address, setAddress] = useState('')
+  const acc = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('acc') || undefined;
+  }, [])
+  const [address, setAddress] = useState<string | undefined>(acc)
   const [hash, setHash] = useState<string>()
   const [error, setError] = useState<string>()
   const [inProgress, setInProgress] = useState(false)


### PR DESCRIPTION
Add optional query param `acc` to auto fill faucet input field on page load. I'm adding this so we can link to it from other dApps and save the user some time.

<img width="1452" alt="Screen Shot 2023-06-06 at 7 08 39 PM" src="https://github.com/paritytech/ink-docs/assets/2101499/e9b13722-fcde-4a91-bb71-81fea9c17486">
