### PR TITLE
fix: update docs

### DIFF
--- a/docs/monthly-update/2022/05.md
+++ b/docs/monthly-update/2022/05.md
@@ -19,7 +19,7 @@ a curated list of awesome projects related to ink!.
 
 ## Playground 🕹
 
-The ink! playground has been published!
+The ink! playground has been published at [https://ink-playground.substrate.io](https://ink-playground.substrate.io)!
 
 It's handy for a couple of things. For example:
 

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/05.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/05.md
@@ -19,7 +19,7 @@ a curated list of awesome projects related to ink!.
 
 ## Playground 🕹
 
-The ink! playground has been published!
+The ink! playground has been published at [https://ink-playground.substrate.io](https://ink-playground.substrate.io)!
 
 It's handy for a couple of things. For example:
 


### PR DESCRIPTION
Add reference to ink-playground back. The URLs were not dead, just down from K8s...