### PR TITLE
fix: typo in basics

### DIFF
--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -27,7 +27,7 @@ Substrate contracts may store types that are encodable and decodable with
 [Parity Codec](https://github.com/paritytech/parity-codec) which includes most Rust common data
 types such as `bool`, `u{8,16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.
 
-Futhermore, ink! provides [substrate](https://substrate.io/) specific types like `AccountId`, `Balance`, and `Hash` to smart contracts as if
+Furthermore, ink! provides [substrate](https://substrate.io/) specific types like `AccountId`, `Balance`, and `Hash` to smart contracts as if
 they were primitive types.
 
 ### String, Vector and More


### PR DESCRIPTION
Found typo when I reading the docs.