### PR TITLE
Updating rococo-faucet endpoint

### DIFF
--- a/docs/testnet/Faucet.tsx
+++ b/docs/testnet/Faucet.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react'
 import ReCAPTCHA from 'react-google-recaptcha'
 
 const RECAPTCHA_SITE_KEY = '6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe'
-const FAUCET_URL = 'https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip/web'
+const FAUCET_URL = 'https://rococo-faucet.parity-testnet.parity.io/drip/web'
 
 const Faucet = () => {
   const [captcha, setCaptcha] = useState<string | null>(null)

--- a/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/testnet/Faucet.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import ReCAPTCHA from 'react-google-recaptcha'
 
 const RECAPTCHA_SITE_KEY = '6LdU5kckAAAAANktvvAKJ0auYUBRP0su94G7WXwe'
-const FAUCET_URL = 'https://ink-docs-rococo-faucet.parity-testnet.parity.io/drip/web'
+const FAUCET_URL = 'https://rococo-faucet.parity-testnet.parity.io/drip/web'
 
 const Faucet = () => {
   const [captcha, setCaptcha] = useState<string | null>(null)


### PR DESCRIPTION
As we're now providing both web and matrix faucets for each network
(alongside these docs), we decided to drop "ink-docs" prefix, when
merging web and matrix rococo faucets.
New endpoint is already deployed and the old one will be disabled
afterwards.
