### PR TITLE
Cj13th fix typo in payable doc

### DIFF
--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -96,7 +96,7 @@ pub enum Status {
 
 ### Struct
 
-You can combine all the above mentioned types even in a custom `struct` you can than store in the contracts storage.
+You can even combine all the above mentioned types in a custom `struct` which you can then store in the contract's storage.
 
 ```rust
 mod MyContract {

--- a/docs/getting-started/calling.md
+++ b/docs/getting-started/calling.md
@@ -63,7 +63,7 @@ Press **"Read"** and confirm that it returns the value `false`:
 
 So let's make the value turn `true` now!
 
-The alternative message to send with the UI is `flip()`. Again, accept the default values for the other options and click **Call**
+The alternative message to send with the UI is `flip()`. Again, accept the default values for the other options and click **Call contract**
 
 ![An image of a Flipper transaction](/img/send-as-transaction.png)
 

--- a/docs/macros-attributes/payable.md
+++ b/docs/macros-attributes/payable.md
@@ -54,7 +54,7 @@ mod flipper {
 ```rust
 #[ink(message, payable)]
 pub fn pay_me(&self) {
-    let _transferred = self.env().transferred_balance();
+    let _transferred = self.env().transferred_value();
 }
 ```
 


### PR DESCRIPTION
**`transferred_value`** is the correct name for the function according to the latest [docs](https://docs.rs/ink_env/4.2.1/ink_env/index.html)

