### PR TITLE
Update the prelude description in storing-values.md

### DIFF
--- a/docs/basics/storing-values.md
+++ b/docs/basics/storing-values.md
@@ -32,7 +32,9 @@ they were primitive types.
 
 ### String, Vector and More
 
-As ink! operates in a `no_std` environment we need bring our own definitions for data types included in `std` like `String` and `Vec`. The [`ink_prelude`](https://docs.rs/ink_prelude/latest/ink_prelude/index.html) crate offers such definitions for most common `std` data types and can be safely used in an ink! contract.
+The [`ink_prelude`](https://docs.rs/ink_prelude/latest/ink_prelude/index.html) crate provides an efficient approach to import commonly used Rust types such as `String` and `Vec`, ensuring safe usage within an ink! contract.
+
+This simplifies the type referencing process between the `std` and `no_std` environments. Typically, these types are defined within the `std` crate in the `std` environment, and the `alloc` crate in the `no_std` environment. Given that ink! smart contract code is compiled in both environments (`no_std` for production and `std` for unit tests), developers might find themselves writing intricate conditional compilation macros. The `ink_prelude` crate conveniently re-exports these types, eliminating this complexity.
 
 You can use the prelude definitions like this:
 


### PR DESCRIPTION
The prelude is basically an re-export of the existing rust types in `std` and `no_std` environments. The old doc was misleading because it implied the types were created specifically for ink, not an re-export of the standard rust types. This PR address the underlying mechanism, and also suggests that the types are interchangeable with the standard types.