### PR TITLE
doc: fix timestamp, payble and contract_balance

### DIFF
--- a/docs/intro/ink-vs-solidity.md
+++ b/docs/intro/ink-vs-solidity.md
@@ -333,8 +333,6 @@ assert!(some_value < 10, "some_value is not less than 10");
 ```c++
 // solidity
 block.timestamp
-// or
-now
 ```
 
 ```rust
@@ -387,7 +385,7 @@ function myFunction() payable returns (uint64) {}
 
 ```rust
 #[ink(message, payable)]
-pub fn my_function() -> (u64) {}
+pub fn my_function(&self) -> u64 {}
 ```
 
 ### `received deposit / payment`
@@ -406,7 +404,7 @@ self.env().transferred_value()
 
 ```c++
 // solidity
-this.balance
+address(this).balance
 ```
 
 ```rust
@@ -439,7 +437,7 @@ event MyCoolEvent(
 );
 
 // emit event
-MyCoolEvent (someValue, someOtherValue)
+emit MyCoolEvent(someValue, someOtherValue);
 ```
 
 ```rust
@@ -487,7 +485,7 @@ In general, `Result::Err` should be used when a _calling contract_ needs to know
 
 ```c++
 // Solidity
-function myFunction(bool returnError) public {
+function myFunction(bool returnError) public pure {
     require(!returnError, "my error here");
 
     // or


### PR DESCRIPTION
## Description
- Minor ink! and Solidity syntax fixes.
- Removed outdated `now` reference from Solidity.