### PR TITLE
fix: update link to DEx demo

### DIFF
--- a/docs/monthly-update/2022/10.md
+++ b/docs/monthly-update/2022/10.md
@@ -31,7 +31,7 @@ see where this is going!
 
 They are working on a UI for the DEX as well. You can find
 the repository here:
-[`AstarNetwork/wasm-showcase-dapps`](https://github.com/AstarNetwork/wasm-showcase-dapps).
+[`AstarNetwork/wasm-tutorial-dex`](https://github.com/AstarNetwork/wasm-tutorial-dex).
 
 ## Release Updates 🆕
 


### PR DESCRIPTION
Outdated links are causing `markdown-link-check` check to fail during pull request checks.

## Description
`Old link`: https://github.com/AstarNetwork/wasm-showcase-dapps
`Replaced by`: https://github.com/AstarNetwork/wasm-tutorial-dex

## Impact
This PR fixes failure associated with DEx demo repo link.