### PR TITLE
fix: update link to upgradeable-contracts

### DIFF
--- a/docs/basics/upgradeability.md
+++ b/docs/basics/upgradeability.md
@@ -235,4 +235,4 @@ for more details.
 ## Examples
 
 Examples of upgradable contracts can be found in the 
-[ink! repository](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts).
+[ink! repository](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts).

--- a/docs/examples/contracts.md
+++ b/docs/examples/contracts.md
@@ -44,10 +44,10 @@ Some of the most interesting ones:
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
+        <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
         <p>
             An upgradeable contract.<br/>
-            <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts">
+            <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts">
                 » view example
             </a>
         </p>

--- a/docs/intro/intro.mdx
+++ b/docs/intro/intro.mdx
@@ -237,10 +237,10 @@ hide_table_of_contents: false
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
+        <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
         <p>
             An upgradeable contract.<br/>
-            <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts">
+            <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts">
                 » view example
             </a>
         </p>

--- a/docs/monthly-update/2022/03.md
+++ b/docs/monthly-update/2022/03.md
@@ -64,7 +64,7 @@ This required some work in both `pallet-contracts` and ink!. Shoutout to the tea
 at [Supercolony](https://supercolony.net/) for driving the development here!
 
 We now have two example contracts for writing upgradeable contracts in ink!.
-[See here](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts)
+[See here](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts)
 for a deeper explanation.
 
 ## Workshop & Talk at EthDenver

--- a/docs/monthly-update/2022/04.md
+++ b/docs/monthly-update/2022/04.md
@@ -7,7 +7,7 @@ slug: /monthly-update/2022/04
 
 For ink! we released [v3.0.1](https://github.com/paritytech/ink/releases/tag/v3.0.1) with
 minor bugfixes. Besides that we made a number of improvements to our examples ‒ mostly to
-our [upgradeable contracts examples](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts).
+our [upgradeable contracts examples](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts).
 
 For [`cargo-contract`](https://github.com/paritytech/cargo-contract) we released
 [v1.1.1](https://github.com/paritytech/cargo-contract/releases/tag/v1.1.1) and

--- a/i18n/es/docusaurus-plugin-content-docs/current/basics/upgradeability.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/basics/upgradeability.md
@@ -232,4 +232,4 @@ para más detaller.
 ## Ejemplos
 
 Puedes ver ejemplos de actualizaciones de contratos en el  
-[repositorio ink!](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts).
+[repositorio ink!](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts).

--- a/i18n/es/docusaurus-plugin-content-docs/current/examples/contracts.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/examples/contracts.md
@@ -44,10 +44,10 @@ Algunos de los más interesantes son:
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
+        <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
         <p>
             Un contrato actualizable.<br/>
-            <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts">
+            <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts">
                 » ver ejemplo
             </a>
         </p>

--- a/i18n/es/docusaurus-plugin-content-docs/current/intro/intro.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/intro/intro.mdx
@@ -217,10 +217,10 @@ hide_table_of_contents: false
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
+        <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
         <p>
             Un contrato actualizable.<br/>
-            <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts">
+            <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts">
                 » ver ejemplo
             </a>
         </p>

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/basics/upgradeability.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/basics/upgradeability.md
@@ -230,4 +230,4 @@ for more details.
 ## Examples
 
 Examples of upgradable contracts can be found in the 
-[ink! repository](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts)
+[ink! repository](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts)

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/03.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/03.md
@@ -64,7 +64,7 @@ This required some work in both `pallet-contracts` and ink!. Shoutout to the tea
 at [Supercolony](https://supercolony.net/) for driving the development here!
 
 We now have two example contracts for writing upgradeable contracts in ink!.
-[See here](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts)
+[See here](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts)
 for a deeper explanation.
 
 ## Workshop & Talk at EthDenver

--- a/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/04.md
+++ b/i18n/es/docusaurus-plugin-content-docs/version-3.x/monthly-update/2022/04.md
@@ -7,7 +7,7 @@ slug: /monthly-update/2022/04
 
 For ink! we released [v3.0.1](https://github.com/paritytech/ink/releases/tag/v3.0.1) with
 minor bugfixes. Besides that we made a number of improvements to our examples ‒ mostly to
-our [upgradeable contracts examples](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts).
+our [upgradeable contracts examples](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts).
 
 For [`cargo-contract`](https://github.com/paritytech/cargo-contract) we released
 [v1.1.1](https://github.com/paritytech/cargo-contract/releases/tag/v1.1.1) and

--- a/versioned_docs/version-3.x/basics/upgradeability.md
+++ b/versioned_docs/version-3.x/basics/upgradeability.md
@@ -230,4 +230,4 @@ for more details.
 ## Examples
 
 Examples of upgradable contracts can be found in the 
-[ink! repository](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts)
+[ink! repository](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts)

--- a/versioned_docs/version-3.x/intro/intro.mdx
+++ b/versioned_docs/version-3.x/intro/intro.mdx
@@ -120,10 +120,10 @@ hide_table_of_contents: false
 
 <div className="row">
     <div className="col text--center">
-        <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
+        <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts"><img src="/img/icons/upgradable.svg" width="100" /></a>
         <p>
             An upgradeable contract.<br/>
-            <a href="https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts">
+            <a href="https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts">
                 » view example
             </a>
         </p>


### PR DESCRIPTION
Outdated links are causing `markdown-link-check`
check to fail during pull request checks.

## Description
- `Old link`: [../paritytech/ink-examples/tree/main/upgradeable-contracts](https://github.com/paritytech/ink-examples/tree/main/upgradeable-contracts)
- `Replaced by`: [ ../paritytech/ink/tree/master/integration-tests/upgradeable-contracts](https://github.com/paritytech/ink/tree/master/integration-tests/upgradeable-contracts)

## Impact
This PR fixes failure associated with upgradeable-contracts link.