### PR TITLE
fix: Useless '--release' argument removed

### DIFF
--- a/docs/basics/verification/contract-verification.md
+++ b/docs/basics/verification/contract-verification.md
@@ -114,7 +114,7 @@ If you are building a multi-contract project,
 make sure you are executing the build in the parent directory in order to mount the directory 
 of all contracts to be visible. Specify a relative manifest path to the root contract: 
 
-`cargo contract build --verifiable --release --manifest-path ink-project-a/Cargo.toml`
+`cargo contract build --verifiable --manifest-path ink-project-a/Cargo.toml`
 :::
 
 You can find a Dockefile and further documentation on image usage 


### PR DESCRIPTION
When trying to execute a verifiable build command on the [ink-examples](https://github.com/paritytech/ink-examples) project, I face the following error:

```
cargo contract build --verifiable --release --manifest-path erc20/Cargo.toml
 [==] Started the build inside the container: ink-verified-erc20-85794
error: the argument '--release' cannot be used multiple times

Usage: cargo contract build [OPTIONS]

For more information, try '--help'.
ERROR: Failed to read build result from docker build
```

I think the `--release` argument is useless based on this explanation from the [cargo-contract](https://github.com/paritytech/cargo-contract/blob/19907468e3c512f1576b6f013304382e72718736/build-image/README.md?plain=1#L22) tool:

https://github.com/paritytech/cargo-contract/blob/19907468e3c512f1576b6f013304382e72718736/build-image/README.md?plain=1#L22
