### PR TITLE
fix: Useless '--contract' argument removed

### DIFF
--- a/docs/basics/verification/contract-verification.md
+++ b/docs/basics/verification/contract-verification.md
@@ -81,7 +81,7 @@ There are two options when it comes to verification:
 `cargo contract verify` allows you to verify the given cargo project
 against a reference contract bundle. 
 
-Simply run `cargo contract verify --contract <path>` 
+Simply run `cargo contract verify <path>` 
 in the cargo project directory. 
 
 If the reference contract was not build inside a docker container, the command


### PR DESCRIPTION
The reference contract path is a mandatory input according to the implementation of the `verify` command:

https://github.com/paritytech/cargo-contract/blob/238d2205eeba2659ba7e1961931f9aafe51a527c/crates/cargo-contract/src/cmd/verify.rs#L43-L59

Then the `--contract` argument becomes useless.
