### PR TITLE
Update migrating-from-ink-4-to-5.md

### DIFF
--- a/versioned_docs/version-5.x/faq/migrating-from-ink-4-to-5.md
+++ b/versioned_docs/version-5.x/faq/migrating-from-ink-4-to-5.md
@@ -583,5 +583,6 @@ It can be used to call a runtime dispatchable from an ink! contract.
 
 You can find a contract example and a comparison with chain extensions
 [here](https://github.com/paritytech/ink/tree/master/integration-tests/call-runtime).
-We've added an example of how to end-to-end test
-`call_runtime` [here](https://github.com/paritytech/ink/tree/master/integration-tests/e2e-call-runtime).
+We've added an example contract with 
+`call_runtime` [here](https://github.com/paritytech/ink/tree/master/integration-tests/call-runtime)
+


### PR DESCRIPTION
Reference the call_runtime example instead of the e2e-test::runtime_call one