### PR TITLE
Update crates' docs links to v5.0.0-rc.1

### DIFF
--- a/versioned_docs/version-5.x/basics/env-functions.md
+++ b/versioned_docs/version-5.x/basics/env-functions.md
@@ -8,7 +8,7 @@ slug: /basics/environment-functions
 # Environment Functions
 
 ink! exposes a number of handy environment functions.
-A full overview [is found here](https://docs.rs/ink_env/4.0.0/ink_env/#functions).
+A full overview [is found here](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/#functions).
 
 In an `#[ink(constructor)]`  use `Self::env()` to access those,
 in an `#[ink(message)]` use `self.env()`.
@@ -16,11 +16,11 @@ So e.g. `Self::env().caller()` or `self.env().caller()`.
 
 Some handy functions include:
 
-* [`caller()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.caller.html): Returns the address of the caller of the executed contract.
-* [`account_id()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.account_id.html): Returns the account ID of the executed contract.
-* [`balance()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.balance.html): Returns the balance of the executed contract.
-* [`block_number()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.block_number.html): Returns the current block number.
-* [`emit_event(…)`](https://docs.rs/ink_env/4.0.0/ink_env/fn.emit_event.html): Emits an event with the given event data.
-* [`transfer(…)`](https://docs.rs/ink_env/4.0.0/ink_env/fn.transfer.html): Transfers value from the contract to the destination account ID.
-* [`hash_bytes(…)`](https://docs.rs/ink_env/4.0.0/ink_env/fn.hash_bytes.html): Conducts the crypto hash of the given input and stores the result in output.
-* […and many more](https://docs.rs/ink_env/4.0.0/ink_env/#functions).
+* [`caller()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.caller.html): Returns the address of the caller of the executed contract.
+* [`account_id()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.account_id.html): Returns the account ID of the executed contract.
+* [`balance()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.balance.html): Returns the balance of the executed contract.
+* [`block_number()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.block_number.html): Returns the current block number.
+* [`emit_event(…)`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.emit_event.html): Emits an event with the given event data.
+* [`transfer(…)`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.transfer.html): Transfers value from the contract to the destination account ID.
+* [`hash_bytes(…)`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.hash_bytes.html): Conducts the crypto hash of the given input and stores the result in output.
+* […and many more](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/#functions).

--- a/versioned_docs/version-5.x/basics/metadata.md
+++ b/versioned_docs/version-5.x/basics/metadata.md
@@ -203,7 +203,7 @@ comes from the smart contracting language itself, and not the contract nor the u
 environment (e.g `pallet-contracts`).
 
 All ink! messages and constructors now return a `Result` which uses this as the `Error`
-variant (see the [`LangError`](https://docs.rs/ink/4.0.0/ink/enum.LangError.html) docs for more).
+variant (see the [`LangError`](https://docs.rs/ink/5.0.0-rc.1/ink/enum.LangError.html) docs for more).
 
 :::
 

--- a/versioned_docs/version-5.x/basics/trait-definitions.md
+++ b/versioned_docs/version-5.x/basics/trait-definitions.md
@@ -95,7 +95,7 @@ Marks trait definitions to ink! as special ink! trait definitions.
 
 There are some restrictions that apply to ink! trait definitions that
 this macro checks. Also ink! trait definitions are required to have specialized
-structure so that the main [`#[ink::contract]`](https://docs.rs/ink/4.0.0/ink/attr.contract.html) macro can
+structure so that the main [`#[ink::contract]`](https://docs.rs/ink/5.0.0-rc.1/ink/attr.contract.html) macro can
 properly generate code for its implementations.
 
 # Example: Definition

--- a/versioned_docs/version-5.x/datastructures/custom.md
+++ b/versioned_docs/version-5.x/datastructures/custom.md
@@ -14,13 +14,13 @@ also create their own custom data structures.
 
 ## Using custom types on storage
 Any custom type wanting to be compatible with ink! storage must implement the
-[`Storable`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/trait.Storable.html)
+[`Storable`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/trait.Storable.html)
 trait, so it can be SCALE
 [`encoded`](https://docs.rs/parity-scale-codec/3.2.2/parity_scale_codec/trait.Encode.html)
 and
 [`decoded`](https://docs.rs/parity-scale-codec/3.2.2/parity_scale_codec/trait.Decode.html).
 Additionally, the traits
-[`StorageLayout`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/trait.StorageLayout.html)
+[`StorageLayout`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/trait.StorageLayout.html)
 and [`TypeInfo`](https://docs.rs/scale-info/2.3.1/scale_info/trait.TypeInfo.html)
 are required as well. But don't worry, usually these traits can just be derived:
 
@@ -42,7 +42,7 @@ pub struct ContractStorage {
 ```
 
 Even better: there is a macro
-[`#[ink::storage_item]`](https://docs.rs/ink_macro/4.0.0/ink_macro/attr.storage_item.html),
+[`#[ink::storage_item]`](https://docs.rs/ink_macro/5.0.0-rc.1/ink_macro/attr.storage_item.html),
 which derives all necessary traits for you. If there is no need to implement any special
 behavior, the above code example can be simplified further as follows:
 
@@ -65,10 +65,10 @@ the relevant trait documentations for more information.
 :::note
 
 The `#[ink::storage_item]` macro is responsible for storage key calculation of 
-non-[`Packed`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/trait.Packed.html) 
+non-[`Packed`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/trait.Packed.html) 
 types. Without it, the key for non-`Packed` fields will be zero. Using this macro is 
 necessary if you don't plan to use a
-[`ManualKey`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/struct.ManualKey.html) 
+[`ManualKey`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/struct.ManualKey.html) 
 on a non-`Packed` type.
 
 Types with custom implementations of the ink! storage traits can still use this macro only 
@@ -81,7 +81,7 @@ for key calculation by disabling the derives: `#[ink::storage_item(derive = fals
 It is possible to use generic data types in your storage, as long as any generic type
 satisfies the required storage trait bounds. In fact, we already witnessed this in the
 previous sections about the
-[`Mapping`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Mapping.html).
+[`Mapping`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Mapping.html).
 
 Let's say you want a mapping where accessing a non-existent key should just return
 it's default value, akin to how mappings work in Solidity. Additionally, you want to know

--- a/versioned_docs/version-5.x/datastructures/mapping.md
+++ b/versioned_docs/version-5.x/datastructures/mapping.md
@@ -8,7 +8,7 @@ hide_title: true
 
 # Working with Mapping
 
-In this section we demonstrate how to work with ink! [`Mapping`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Mapping.html).
+In this section we demonstrate how to work with ink! [`Mapping`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Mapping.html).
 
 Here is an example of a mapping from a user to a `Balance`:
 

--- a/versioned_docs/version-5.x/datastructures/overview.md
+++ b/versioned_docs/version-5.x/datastructures/overview.md
@@ -10,8 +10,8 @@ hide_title: true
 
 The `ink_storage` crate acts as the standard storage library for ink! smart contracts.
 At the moment it provides two primitives for interacting with storage,
-[`Mapping`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Mapping.html)
-and [`Lazy`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Lazy.html).
+[`Mapping`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Mapping.html)
+and [`Lazy`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Lazy.html).
 
 `Mapping` is a mapping of key-value pairs directly to the contract storage. It is very
 similar to traditional hash tables and comparable to the `mapping` type Solidity offers.

--- a/versioned_docs/version-5.x/datastructures/storage-in-metadata.md
+++ b/versioned_docs/version-5.x/datastructures/storage-in-metadata.md
@@ -72,7 +72,7 @@ The storage will be reflected inside the metadata as like follows:
 
 We observe that the storage layout is represented as a tree, where tangible storage values
 end up inside a `leaf`. Because of
-[`Packed`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/trait.Packed.html)
+[`Packed`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/trait.Packed.html)
 encoding, leafs can share the same storage key, and
 in order to reach them you'd need to fetch and decode the whole storage cell under this key.
 

--- a/versioned_docs/version-5.x/datastructures/storage-layout.md
+++ b/versioned_docs/version-5.x/datastructures/storage-layout.md
@@ -31,7 +31,7 @@ extent, the storage API works similar to a traditional key-value database.
 ## Packed vs Non-Packed layout
 
 Types that can be stored entirely under a single storage cell are considered
-[`Packed`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/trait.Packed.html).
+[`Packed`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/trait.Packed.html).
 By default, ink! tries to store all storage struct fields under a single storage cell.
 Consequentially, with a `Packed` storage layout, any message interacting with the contract
 storage will always need to operate on the entire contract storage struct.
@@ -132,10 +132,10 @@ large or sparse arrays on contract storage, consider using a `Mapping` instead.
 ## Manual vs. Automatic Key Generation
 
 By default, keys are calculated automatically for you, thanks to the
-[`AutoKey`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/struct.AutoKey.html)
+[`AutoKey`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/struct.AutoKey.html)
 primitive. They'll be generated at compile time and ruled out for conflicts.
 However, for non-`Packed` types like `Lazy` or the `Mapping`, the
-[`ManualKey`](https://docs.rs/ink_storage_traits/4.0.0/ink_storage_traits/struct.ManualKey.html)
+[`ManualKey`](https://docs.rs/ink_storage_traits/5.0.0-rc.1/ink_storage_traits/struct.ManualKey.html)
 primitive allows manual control over the storage key of a field like so:
 
 ```rust

--- a/versioned_docs/version-5.x/faq/faq.md
+++ b/versioned_docs/version-5.x/faq/faq.md
@@ -94,7 +94,7 @@ See the [Chain Extensions](/macros-attributes/chain-extension) section for more 
 
 Please see [this section](/macros-attributes/contract#env-impl-environment) in our documentation.
 
-Detailed documentation is found in [the Rust docs](https://docs.rs/ink_macro/4.0.0/ink_macro/attr.contract.html#header-arguments)
+Detailed documentation is found in [the Rust docs](https://docs.rs/ink_macro/5.0.0-rc.1/ink_macro/attr.contract.html#header-arguments)
 for the `#[ink(contract)]` macro. It allows you to specify your environment a la
 `#[ink::contract(env = MyEnvironment)]`.
 
@@ -171,15 +171,15 @@ Rust's standard library consists of three different layers:
 
 A number of crypto hashes are built into the [pallet-contracts](/how-it-works) and
 therefore very efficient to use. We currently support a handful of those, you
-can view the complete list [here](https://docs.rs/ink_env/4.0.0/ink_env/hash/trait.CryptoHash.html).
+can view the complete list [here](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/hash/trait.CryptoHash.html).
 
 If you have the urgent need for another crypto hash you could introduce it through
 [Chain Extensions](/macros-attributes/chain-extension)
 or make a proposal to include it into the default set of the `pallet-contracts`.
 
 Using one of the built-in crypto hashes can be done as explained here:
-* [`self.env().hash_bytes()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.hash_bytes.html)
-* [`self.env().hash_encoded()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.hash_encoded.html)
+* [`self.env().hash_bytes()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.hash_bytes.html)
+* [`self.env().hash_encoded()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.hash_encoded.html)
 
 ### Why is it not possible to use floating point data types in ink!? How do I implement returning a decimal number?
 

--- a/versioned_docs/version-5.x/faq/migrating-from-ink-3-to-4.md
+++ b/versioned_docs/version-5.x/faq/migrating-from-ink-3-to-4.md
@@ -91,7 +91,7 @@ we removed support for it in [#1403](https://github.com/paritytech/ink/pull/1403
 
 As part of [#1233](https://github.com/paritytech/ink/pull/1233)
 the `eth_compatibility` crate was removed. The `ecdsa_to_eth_address()`
-function from it can now be found [in the `ink_env` crate](https://docs.rs/ink_env/4.0.0/ink_env/fn.ecdsa_to_eth_address.html).
+function from it can now be found [in the `ink_env` crate](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.ecdsa_to_eth_address.html).
 
 ```rust
 ink_env::ecdsa_to_eth_address(&pub_key, &mut output);
@@ -105,9 +105,9 @@ The return value is the size of the pre-existing value at the specified key if a
 
 Two new useful functions were added:
 
-- [`Mapping::contains(key)`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Mapping.html#method.contains)
+- [`Mapping::contains(key)`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Mapping.html#method.contains)
   in [#1224](https://github.com/paritytech/ink/pull/1224).
-- [`Mapping::take()`](https://docs.rs/ink_storage/4.0.0/ink_storage/struct.Mapping.html#method.take)
+- [`Mapping::take()`](https://docs.rs/ink_storage/5.0.0-rc.1/ink_storage/struct.Mapping.html#method.take)
   to get a value while removing it from storage in [#1461](https://github.com/paritytech/ink/pull/1461).
 
 In case you were working around those two functions you can now
@@ -117,10 +117,10 @@ a `get(key).is_none()` instead of `contains(key)`.
 ## Storage functions in `ink_env`
 
 As part of [#1224](https://github.com/paritytech/ink/pull/1224) the return type
-of [`ink_env::set_contract_storage()`](https://docs.rs/ink_env/4.0.0/ink_env/fn.set_contract_storage.html)
+of [`ink_env::set_contract_storage()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.set_contract_storage.html)
 was changed to return an `Option<u32>` instead of `()`.
 
-A new function [`ink_env::take_contract_storage`](https://docs.rs/ink_env/4.0.0/ink_env/fn.take_contract_storage.html)
+A new function [`ink_env::take_contract_storage`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/fn.take_contract_storage.html)
 was introduced.
 
 ## Removal of `ink_env::random` function
@@ -177,7 +177,7 @@ for constructors `Result<Constructor::Output, LangError>`).
 This happens even if the message/constructor doesn't have a return type,
 we default to the unit type `()` in that case.
 
-A [`LangError`](https://docs.rs/ink/4.0.0/ink/enum.LangError.html)
+A [`LangError`](https://docs.rs/ink/5.0.0-rc.1/ink/enum.LangError.html)
 is a type of error which doesn't originate from the contract itself,
 nor from the underlying execution environment (so the Contracts pallet
 in this case).
@@ -321,14 +321,14 @@ better.
 
 ## Updates to the `CallBuilder` and `CreateBuilder` APIs
 There's been several changes to the
-[`CallBuilder`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html)
+[`CallBuilder`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CallBuilder.html)
 and
-[`CreateBuilder`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CreateBuilder.html)
+[`CreateBuilder`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CreateBuilder.html)
 APIs.
 
 In [#1604](https://github.com/paritytech/ink/pull/1604) we renamed the
 `CallBuilder::fire()` method to
-[`CallBuilder::invoke()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.invoke-2).
+[`CallBuilder::invoke()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CallBuilder.html#method.invoke-2).
 This brings more consistency across our APIs which were already using the `invoke`
 terminology.
 
@@ -337,9 +337,9 @@ we added support for handing
 `LangError`s from the `CreateBuilder` and `CallBuilder`, respectively.
 
 If you want to handle errors from either `Builder` you can use the new
-[`CreateBuilder::try_instantiate()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CreateBuilder.html#method.try_instantiate)
+[`CreateBuilder::try_instantiate()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CreateBuilder.html#method.try_instantiate)
 or
-[`CallBuilder::try_invoke()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.try_invoke-1)
+[`CallBuilder::try_invoke()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CallBuilder.html#method.try_invoke-1)
 methods.
 
 Because of the addition of those methods we also removed any error handling from the
@@ -349,13 +349,13 @@ directly, and panic when they encounter an error.
 
 Lastly, in [#1636](https://github.com/paritytech/ink/pull/1636) we added two methods to
 the `CallBuilder` to streamline
-[`Call`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.Call.html)
+[`Call`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.Call.html)
 and
-[`DelegateCall`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.DelegateCall.html)
+[`DelegateCall`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.DelegateCall.html)
 workflows:
 - For `Call` you can use
-  [`CallBuilder::call()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.call) (this replaces `CallBuilder::callee()`)
-- For `DelegateCall` you can use [`CallBuilder::delegate()`](https://docs.rs/ink_env/4.0.0/ink_env/call/struct.CallBuilder.html#method.delegate)
+  [`CallBuilder::call()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CallBuilder.html#method.call) (this replaces `CallBuilder::callee()`)
+- For `DelegateCall` you can use [`CallBuilder::delegate()`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/call/struct.CallBuilder.html#method.delegate)
 
 ## Removal of `[lib.crate-type]` and `[lib.name]` from contract manifest
 Earlier versions of `cargo-contract` required that these two fields were specified in the

--- a/versioned_docs/version-5.x/testing/debugging.md
+++ b/versioned_docs/version-5.x/testing/debugging.md
@@ -21,8 +21,8 @@ There are three ways to debug your ink! contract currently:
 
 You can use those two macros:
 
-* [`ink::env::debug_println!`](https://docs.rs/ink_env/4.0.0/ink_env/macro.debug_println.html)
-* [`ink::env::debug_print!`](https://docs.rs/ink_env/4.0.0/ink_env/macro.debug_print.html)
+* [`ink::env::debug_println!`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/macro.debug_println.html)
+* [`ink::env::debug_print!`](https://docs.rs/ink_env/5.0.0-rc.1/ink_env/macro.debug_print.html)
 
 There are things you could do to enable debug messages on the client console:
 

--- a/versioned_docs/version-5.x/testing/off-chain.md
+++ b/versioned_docs/version-5.x/testing/off-chain.md
@@ -48,7 +48,7 @@ You then have fine-grained control over how a contract is called;
 for example you can influence the block advancement, the value transferred to it,
 by which account it is called, which storage it is run with, etc..
 
-See the [`examples/erc20`](https://github.com/paritytech/ink-examples/blob/main/erc20/lib.rs) contract on how to utilize those or [the documentation](https://docs.rs/ink/4.0.0/ink/attr.test.html) for details.
+See the [`examples/erc20`](https://github.com/paritytech/ink-examples/blob/main/erc20/lib.rs) contract on how to utilize those or [the documentation](https://docs.rs/ink/5.0.0-rc.1/ink/attr.test.html) for details.
 
 At the moment there are some known limitations to our off-chain environment,
 and we are working on making it behave as close to the real chain environment


### PR DESCRIPTION
This PR updates the crates' corresponding links to docs.rs to match the version 5.x (specifically, 5.0.0-rc.1)