### PR TITLE
fix: update production chains list

### DIFF
--- a/docs/intro/intro.mdx
+++ b/docs/intro/intro.mdx
@@ -155,26 +155,21 @@ hide_table_of_contents: true
 </div>
 
 <div className="row">
-    <div className="col text--left">
-        <h3><img src= "/img/chains/mainnet-soon.svg" className="chainHeader mainnetSoon" /></h3>
-    </div>
-</div>
-
-<div className="row">
     <div className="col text--center">
         <a href="https://t3rn.io">
             <img src= "/img/chains/t3rn.svg" className="chain" />
         </a>
     </div>
     <div className="col text--center">
-        <a href="https://enjin.io">
-            <img src= "/img/chains/enjin.svg" className="chain" />
-        </a>
-    </div>
-    <div className="col text--center">
         <a href="https://zeitgeist.pm">
             <img src= "/img/chains/zeitgeist.svg" className="chain" />
         </a>
+    </div>
+</div>
+
+<div className="row">
+    <div className="col text--left">
+        <h3><img src= "/img/chains/mainnet-soon.svg" className="chainHeader mainnetSoon" /></h3>
     </div>
 </div>
 
@@ -197,6 +192,11 @@ hide_table_of_contents: true
 </div>
 
 <div className="row">
+    <div className="col text--center">
+        <a href="https://enjin.io">
+            <img src= "/img/chains/enjin.svg" className="chain" />
+        </a>
+    </div>
     <div className="col text--center">
         <a href="https://www.ternoa.network/">
             <img src= "/img/chains/ternoa.svg" className="chain" />


### PR DESCRIPTION
Updating the page for "where to deploy" to put t3rn and Zeitgeist as chains in prod. 

Might be worth doing an additional check on whether the list is complete and correct as of today -- not 100% sure! I don't think Enjin is up and running for example.