### PR TITLE
Change `Substrate` to `Polkadot SDK`

### DIFF
--- a/docs/intro/intro.mdx
+++ b/docs/intro/intro.mdx
@@ -37,7 +37,7 @@ hide_table_of_contents: true
   <center>
     <em>
       ink! is a programming language for smart contracts.<br />
-      You can use it with blockchains built on <a href="https://github.com/paritytech/substrate">Substrate</a>.
+      You can use it with blockchains built with the <a href="https://github.com/paritytech/polkadot-sdk">Polkadot SDK</a>.
     </em>
   </center>
 </h3>


### PR DESCRIPTION
The docs still prominently feature `Substrate` which technically is correct but it's also limited to FRAME I guess? Anyways I think it's in general more confusing than helping and therefore should link to Polkadot SDK instead, wdyt? 🤷 


![Screenshot 2024-03-04 at 16 36 22](https://github.com/paritytech/ink-docs/assets/839848/aa96638c-d9b4-4ac9-aa45-9e5414594d15)
