### PR TITLE
fix navigation text color on light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -155,7 +155,7 @@ button:disabled {
 }
 
 .pagination-nav__label {
-  color: #fff;
+  color: var(--ifm-color-content-secondary);
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
### Before
![inkdocsbefore](https://github.com/paritytech/ink-docs/assets/72769566/ce434497-d611-4a9a-b321-736a1c419708)


### After
![inkdocsafter](https://github.com/paritytech/ink-docs/assets/72769566/24f5b894-b0d7-4849-851e-0555291836d3)
